### PR TITLE
Handle InvalidStateError when registering keyboard shortcut

### DIFF
--- a/WME-RSA.user.js
+++ b/WME-RSA.user.js
@@ -2,7 +2,7 @@
 // ==UserScript==
 // @name         WME Road Shield Assistant
 // @namespace    https://greasyfork.org/en/users/286957-skidooguy
-// @version      2026.04.19.001
+// @version      2026.04.23.001
 // @description  Adds shield information display to WME
 // @author       SkiDooGuy, jm6087, Karlsosha
 // @match        https://www.waze.com/editor*
@@ -11,6 +11,7 @@
 // @match        https://beta.waze.com/*/editor*
 // @exclude      https://www.waze.com/user/editor*
 // @require      https://greasyfork.org/scripts/24851-wazewrap/code/WazeWrap.js
+// @require      https://cdn.jsdelivr.net/npm/@turf/turf@7/turf.min.js
 // @grant        GM_xmlhttpRequest
 // @grant        unsafeWindow
 // @connect      greasyfork.org

--- a/WME-RSA.user.js
+++ b/WME-RSA.user.js
@@ -2,7 +2,7 @@
 // ==UserScript==
 // @name         WME Road Shield Assistant
 // @namespace    https://greasyfork.org/en/users/286957-skidooguy
-// @version      2025.12.22.001
+// @version      2026.04.19.001
 // @description  Adds shield information display to WME
 // @author       SkiDooGuy, jm6087, Karlsosha
 // @match        https://www.waze.com/editor*
@@ -11,7 +11,6 @@
 // @match        https://beta.waze.com/*/editor*
 // @exclude      https://www.waze.com/user/editor*
 // @require      https://greasyfork.org/scripts/24851-wazewrap/code/WazeWrap.js
-// @require      https://cdn.jsdelivr.net/npm/@turf/turf@7.3.1/turf.min.js
 // @grant        GM_xmlhttpRequest
 // @grant        unsafeWindow
 // @connect      greasyfork.org
@@ -19,6 +18,7 @@
 // ==/UserScript==
 /* global W */
 /* global WazeWrap */
+/* global turf */
 // import type { Node, Segment, SegmentAddress, Street, Turn, WmeSDK } from "wme-sdk-typings";
 // import type { Point, LineString, Position, Feature } from "geojson";
 // import * as turf from "@turf/turf";
@@ -43,9 +43,8 @@ function rsaInit() {
     const GF_LINK = "https://greasyfork.org/en/scripts/425050-wme-road-shield-assisstant";
     const FORUM_LINK = "https://www.waze.com/discuss/t/script-road-shield-assistant-rsa/227100";
     const RSA_UPDATE_NOTES = `<b>NEW:</b><br>
-    - Make Configurations External and Managed via Google Sheets<br>
+    - Remove Waze Wrap Remote Storage<br>
 <b>BUGFIXES:</b><br>
-    - Issue with Minor Highways or Greater<br>
 <b>KNOWN ISSUES:</b><br><br>`;
     let CountryID;
     (function (CountryID) {

--- a/WME-RSA.user.js
+++ b/WME-RSA.user.js
@@ -1284,10 +1284,10 @@ function rsaInit() {
     }
     async function loadSettings() {
         const localSettings = JSON.parse(localStorage.getItem("RSA_Settings"));
-        const serverSettings = await WazeWrap.Remote.RetrieveSettings("RSA_Settings");
-        if (!serverSettings) {
-            console.error("RSA: Error communicating with WW settings server");
-        }
+        // const serverSettings = await WazeWrap.Remote.RetrieveSettings("RSA_Settings");
+        // if (!serverSettings) {
+        //     console.error("RSA: Error communicating with WW settings server");
+        // }
         const defaultSettings = {
             lastSaveAction: 0,
             enableScript: true,
@@ -1325,13 +1325,12 @@ function rsaInit() {
             iconLayerVisible: false,
         };
         rsaSettings = $.extend({}, defaultSettings, localSettings);
-        if (serverSettings && serverSettings.lastSaveAction > rsaSettings.lastSaveAction) {
-            $.extend(rsaSettings, serverSettings);
-            // console.log('RSA: server settings used');
-        }
-        else {
-            // console.log('RSA: local settings used');
-        }
+        // if (serverSettings && serverSettings.lastSaveAction > rsaSettings.lastSaveAction) {
+        //     $.extend(rsaSettings, serverSettings);
+        //     // console.log('RSA: server settings used');
+        // } else {
+        //     // console.log('RSA: local settings used');
+        // }
         loadMainRoadAbbr();
     }
     async function saveSettings() {
@@ -1404,15 +1403,14 @@ function rsaInit() {
         if (localStorage) {
             localStorage.setItem("RSA_Settings", JSON.stringify(localSettings));
         }
-        const serverSave = await WazeWrap.Remote.SaveSettings("RSA_Settings", localSettings);
-        if (serverSave === null) {
-            console.warn("RSA: User PIN not set in WazeWrap tab");
-        }
-        else {
-            if (serverSave === false) {
-                console.error("RSA: Unable to save settings to server");
-            }
-        }
+        // const serverSave = await WazeWrap.Remote.SaveSettings("RSA_Settings", localSettings);
+        // if (serverSave === null) {
+        //     console.warn("RSA: User PIN not set in WazeWrap tab");
+        // } else {
+        //     if (serverSave === false) {
+        //         console.error("RSA: Unable to save settings to server");
+        //     }
+        // }
     }
     function checkOptions() {
         const countries = sdk.DataModel.Countries.getAll();

--- a/WME-RSA.user.js
+++ b/WME-RSA.user.js
@@ -2,7 +2,7 @@
 // ==UserScript==
 // @name         WME Road Shield Assistant
 // @namespace    https://greasyfork.org/en/users/286957-skidooguy
-// @version      2026.04.23.001
+// @version      2026.06.11.001
 // @description  Adds shield information display to WME
 // @author       SkiDooGuy, jm6087, Karlsosha
 // @match        https://www.waze.com/editor*
@@ -15,6 +15,7 @@
 // @grant        GM_xmlhttpRequest
 // @grant        unsafeWindow
 // @connect      greasyfork.org
+// @connect      docs.google.com
 // @contributionURL https://github.com/WazeDev/Thank-The-Authors
 // ==/UserScript==
 /* global W */
@@ -27,12 +28,22 @@
 // import WazeWrap from "https://greasyfork.org/scripts/24851-wazewrap/code/WazeWrap.js";
 let sdk;
 unsafeWindow.SDK_INITIALIZED.then(() => {
-    if (!unsafeWindow.getWmeSdk) {
-        throw new Error("SDK is not installed");
+    try {
+        console.log("RSA: SDK_INITIALIZED event fired");
+        if (!unsafeWindow.getWmeSdk) {
+            throw new Error("SDK is not installed");
+        }
+        sdk = unsafeWindow.getWmeSdk({ scriptId: "wme-road-shield-assistant", scriptName: "WME Road Shield Assistant" });
+        console.log(`SDK v ${sdk.getSDKVersion()} on ${sdk.getWMEVersion()} initialized`);
+        sdk.Events.once({ eventName: "wme-ready" }).then(rsaInit).catch((e) => {
+            console.error("RSA: Error in rsaInit promise chain", e);
+        });
     }
-    sdk = unsafeWindow.getWmeSdk({ scriptId: "wme-road-shield-assistant", scriptName: "WME Road Shield Assistant" });
-    console.log(`SDK v ${sdk.getSDKVersion()} on ${sdk.getWMEVersion()} initialized`);
-    sdk.Events.once({ eventName: "wme-ready" }).then(rsaInit);
+    catch (e) {
+        console.error("RSA: Error in SDK initialization", e);
+    }
+}).catch((e) => {
+    console.error("RSA: Error in SDK_INITIALIZED promise", e);
 });
 function rsaInit() {
     if (!WazeWrap.Ready) {
@@ -351,6 +362,7 @@ function rsaInit() {
     const CountryDataSheetInfo = {};
     const RoadAbbr = {};
     let mainSheetLoaded = false;
+    const loadingCountries = new Set(); // Track which countries are currently being loaded
     const iconsAllowingNoText = new Set([
         2000, // Atlantic City Expy
         2079, // Garden State Parkway
@@ -706,10 +718,10 @@ function rsaInit() {
                     fillOpacity: 1,
                     fill: "black",
                     stroke: "black",
-                    fontColor: "green",
-                    labelOutlineColor: "white",
-                    labelOutlineWidth: 1,
-                    fontSize: 12,
+                    fontColor: "white",
+                    labelOutlineColor: "black",
+                    labelOutlineWidth: 2,
+                    fontSize: 14,
                     display: "grid",
                     label: "${shieldLabel}",
                     labelYOffset: "${shieldLabelYOffset}",
@@ -945,10 +957,13 @@ function rsaInit() {
         const $rsaFixWrapper = $('<div id="rsa-autoWrapper" class="toolbar-button ItemInactive" style="display:none;margin-right:5px;">');
         const $rsaFixInner = $('<div class="group-title toolbar-top-level-item-title rsa" style="margin:5px 0 0 15px;font-size:12px;">RSA Fix</div>');
         // WazeWrap.Interface.Tab('RSA', $rsaTab.html, setupOptions, 'RSA');
-        sdk.Sidebar.registerScriptTab().then((r) => {
+        sdk.Sidebar.registerScriptTab().then(async (r) => {
+            console.log("RSA: Registering sidebar tab");
             r.tabLabel.innerHTML = "RSA";
             r.tabPane.innerHTML = $rsaTab.html;
-            setupOptions();
+            console.log("RSA: Starting setupOptions");
+            await setupOptions();
+            console.log("RSA: setupOptions complete");
         });
         $(`<style type="text/css">${rsaCss}</style>`).appendTo("head");
         // $($rsaFixInner).appendTo($rsaFixWrapper);
@@ -1011,7 +1026,14 @@ function rsaInit() {
         checkOptions();
     }
     async function setupOptions() {
-        await loadSettings();
+        console.log("RSA: setupOptions started");
+        try {
+            await loadSettings();
+            console.log("RSA: loadSettings complete");
+        }
+        catch (e) {
+            console.error("RSA: Error in loadSettings", e);
+        }
         // Create OL layer for display
         sdk.Map.addLayer({
             layerName: rsaMapLayer.layerName,
@@ -1104,12 +1126,22 @@ function rsaInit() {
         // WazeWrap.Events.register('selectionchanged', null, tryScan);
         sdk.Events.on({ eventName: "wme-map-move-end", eventHandler: updateMap });
         sdk.Events.on({ eventName: "wme-map-zoom-changed", eventHandler: updateMap });
-        sdk.Shortcuts.createShortcut({
-            callback: addShieldClick,
-            description: "Activates the Add Shield Button",
-            shortcutId: "addShield",
-            shortcutKeys: "A+83",
-        });
+        const shortcutKeys = "A+83";
+        const keysInUse = sdk.Shortcuts.areShortcutKeysInUse({ shortcutKeys });
+        if (keysInUse) {
+            console.warn("RSA: Shortcut key A+S was already in use, registering addShield without a key binding.");
+        }
+        try {
+            sdk.Shortcuts.createShortcut({
+                callback: addShieldClick,
+                description: "Activates the Add Shield Button",
+                shortcutId: "addShield",
+                shortcutKeys: keysInUse ? null : shortcutKeys,
+            });
+        }
+        catch (e) {
+            console.error("RSA: Failed to register addShield shortcut:", e);
+        }
         // new WazeWrap.Interface.Shortcut('addShield',
         //                                 'Activates the Add Shield Button',
         //                                 'wmersa',
@@ -1221,73 +1253,149 @@ function rsaInit() {
         $("#rsa-resetSettings").attr("value", Strings[LANG].resetSettings);
         checkOptions();
     }
-    const apiKey = "AIzaSyDJaCD-PqytSPVrXZMLqI2UNIsTuy_yLRY";
     const mainRoadSheetID = "10RiokHwpEdcDu5AotXVBbesAzixDSCm9y5x44TRsToI";
-    async function loadCountryAbbr(countryId, sheetKey) {
-        if (!mainSheetLoaded)
+    const gvizCache = new Map(); // Cache parsed gviz responses by URL
+    async function parseGvizResponse(responseText) {
+        const match = responseText.match(/google\.visualization\.Query\.setResponse\(([\s\S]+)\);/);
+        if (!match) {
+            throw new Error("Failed to parse Google Sheet data");
+        }
+        return JSON.parse(match[1]);
+    }
+    async function gvizFetch(url) {
+        // Return cached parsed response if available
+        if (gvizCache.has(url)) {
+            console.log(`RSA: gvizFetch (cached) for URL: ${url}`);
+            return gvizCache.get(url);
+        }
+        console.log(`RSA: gvizFetch called with URL: ${url}`);
+        const promise = new Promise((resolve, reject) => {
+            GM_xmlhttpRequest({
+                method: "GET",
+                url: url,
+                timeout: 10000,
+                onload: (response) => {
+                    console.log(`RSA: gviz request to ${url} returned status ${response.status}`);
+                    if (response.status === 200) {
+                        try {
+                            const json = parseGvizResponse(response.responseText);
+                            resolve(json);
+                        }
+                        catch (e) {
+                            reject(e);
+                        }
+                    }
+                    else {
+                        const err = new Error(`HTTP ${response.status}: ${response.statusText} from ${url}`);
+                        console.error(`RSA: HTTP error`, err);
+                        reject(err);
+                    }
+                },
+                onerror: (err) => {
+                    console.error("RSA: gviz request error", err);
+                    reject(err);
+                },
+                ontimeout: () => {
+                    console.error("RSA: gviz request timeout");
+                    reject(new Error("Request timeout"));
+                },
+            });
+        });
+        // Cache the promise
+        gvizCache.set(url, promise);
+        return promise;
+    }
+    async function loadCountryAbbr(countryId, sheetKey, stateName) {
+        if (!mainSheetLoaded || loadingCountries.has(countryId))
             return;
-        // Load road abbreviation data
-        $.ajaxSetup({ async: false });
-        await $.getJSON(`https://sheets.googleapis.com/v4/spreadsheets/${sheetKey}?includeGridData=true&key=${apiKey}`)
-            .done(async (spreadSheet) => {
+        loadingCountries.add(countryId);
+        try {
             const countryWide = {};
-            let setCountry = false;
-            for (const sheet of spreadSheet.sheets) {
-                if (sheet.properties.title === "Reference")
-                    continue;
-                if (sheet.data[0].rowData.length <= 1)
-                    continue;
-                const stateWide = {};
-                for (const row of sheet.data[0].rowData) {
-                    if (row.values && row.values.length >= 2) {
-                        const matchingRegex = row.values[0].formattedValue;
-                        if (matchingRegex === "Matching Condition")
-                            continue;
-                        const shieldId = Number.parseInt(row.values[1].formattedValue, 10);
-                        stateWide[matchingRegex] = shieldId;
+            // Determine which sheets to load
+            let sheetsToLoad = [""]; // Always load country-wide (default) sheet
+            // If a specific state is requested, load only that state + country-wide
+            if (stateName) {
+                sheetsToLoad.push(stateName);
+            }
+            else {
+                // Initial load: just load country-wide sheet for fast startup
+                // State sheets will be loaded on-demand when needed
+                sheetsToLoad = [""];
+            }
+            // Load sheets in parallel
+            const sheetPromises = sheetsToLoad.map(async (sheetName) => {
+                try {
+                    const sheetUrl = sheetName
+                        ? `https://docs.google.com/spreadsheets/d/${sheetKey}/gviz/tq?tqx=out:json&sheet=${encodeURIComponent(sheetName)}`
+                        : `https://docs.google.com/spreadsheets/d/${sheetKey}/gviz/tq?tqx=out:json`;
+                    const json = await gvizFetch(sheetUrl);
+                    if (json.table && json.table.rows && json.table.rows.length > 0) {
+                        const sheetData = {};
+                        for (const row of json.table.rows) {
+                            if (!row.c || row.c.length < 2)
+                                continue;
+                            const abbr = row.c[0]?.v;
+                            const iconIdValue = row.c[1]?.v;
+                            if (!abbr || typeof abbr !== "string" || iconIdValue === null || iconIdValue === undefined)
+                                continue;
+                            const iconID = typeof iconIdValue === "number" ? iconIdValue : parseInt(iconIdValue, 10);
+                            sheetData[abbr] = iconID;
+                        }
+                        return { sheetName, sheetData, count: Object.keys(sheetData).length };
                     }
                 }
-                countryWide[sheet.properties.title] = stateWide;
-                setCountry = true;
+                catch (e) {
+                    // Sheet might not exist, skip it
+                }
+                return null;
+            });
+            const results = await Promise.allSettled(sheetPromises);
+            for (const result of results) {
+                if (result.status === "fulfilled" && result.value) {
+                    const { sheetName, sheetData } = result.value;
+                    countryWide[sheetName] = sheetData;
+                }
             }
-            if (setCountry)
+            if (Object.keys(countryWide).length > 0 && Object.values(countryWide).some(state => Object.keys(state).length > 0)) {
                 RoadAbbr[countryId] = countryWide;
-        }).fail(() => {
-            console.error("RSA: Unable to load road abbreviation data from Google Sheets");
-        });
-        $.ajaxSetup({ async: true });
+            }
+        }
+        catch (e) {
+            console.error("RSA: Unable to load road abbreviation data from Google Sheets", e);
+        }
+        finally {
+            loadingCountries.delete(countryId);
+        }
     }
-    function loadMainRoadAbbr() {
-        $.getJSON(`https://sheets.googleapis.com/v4/spreadsheets/${mainRoadSheetID}?includeGridData=true&key=${apiKey}`, (spreadSheet) => {
-            for (const sheet of spreadSheet.sheets) {
-                if (sheet.properties.title === "CountryData") {
-                    for (const row of sheet.data[0].rowData) {
-                        if (row.values && row.values.length >= 2) {
-                            const country = row.values[0].formattedValue;
-                            if (country === "Country")
-                                continue;
-                            const countryCode = Number.parseInt(row.values[1].formattedValue, 10);
-                            if (row.values.length >= 3) {
-                                const sheetKey = row.values[2].formattedValue;
-                                CountryDataSheetInfo[countryCode] = sheetKey;
-                            }
-                        }
+    async function loadMainRoadAbbr() {
+        try {
+            const gvizUrl = `https://docs.google.com/spreadsheets/d/${mainRoadSheetID}/gviz/tq?tqx=out:json&sheet=${encodeURIComponent("CountryData")}`;
+            const json = await gvizFetch(gvizUrl);
+            if (json.table && json.table.rows) {
+                for (const row of json.table.rows) {
+                    if (!row.c || row.c.length < 3)
+                        continue;
+                    const country = row.c[0]?.v;
+                    if (!country || country === "Country")
+                        continue;
+                    const countryCode = parseInt(row.c[1]?.v ?? "0", 10);
+                    const sheetKey = row.c[2]?.v;
+                    if (countryCode && sheetKey) {
+                        CountryDataSheetInfo[countryCode] = sheetKey;
                     }
                 }
             }
             mainSheetLoaded = true;
-        }).done(() => {
             console.log("RSA: Main Road Abbreviations are Loaded");
-        }).fail(() => {
-            console.error("RSA: Unable to load road abbreviation data from Google Sheets");
-        });
+        }
+        catch (e) {
+            console.error("RSA: Unable to load road abbreviation data from Google Sheets", e);
+        }
     }
     async function loadSettings() {
+        console.log("RSA: loadSettings started");
         const localSettings = JSON.parse(localStorage.getItem("RSA_Settings"));
-        // const serverSettings = await WazeWrap.Remote.RetrieveSettings("RSA_Settings");
-        // if (!serverSettings) {
-        //     console.error("RSA: Error communicating with WW settings server");
-        // }
+        console.log("RSA: localSettings parsed, calling loadMainRoadAbbr");
         const defaultSettings = {
             lastSaveAction: 0,
             enableScript: true,
@@ -1325,13 +1433,7 @@ function rsaInit() {
             iconLayerVisible: false,
         };
         rsaSettings = $.extend({}, defaultSettings, localSettings);
-        // if (serverSettings && serverSettings.lastSaveAction > rsaSettings.lastSaveAction) {
-        //     $.extend(rsaSettings, serverSettings);
-        //     // console.log('RSA: server settings used');
-        // } else {
-        //     // console.log('RSA: local settings used');
-        // }
-        loadMainRoadAbbr();
+        await loadMainRoadAbbr();
     }
     async function saveSettings() {
         const { enableScript, HighSegShields, ShowSegShields, SegShieldMissing, SegShieldError, HighNodeShields, ShowNodeShields, ShowExitShields, SegHasDir, SegInvDir, ShowTurnTTS, AlertTurnTTS, ShowTowards, ShowVisualInst, NodeShieldMissing, HighSegClr, MissSegClr, ErrSegClr, HighNodeClr, MissNodeClr, SegHasDirClr, SegInvDirClr, TitleCaseClr, TitleCaseSftClr, ShowRamps, AlternativeShields, mHPlus, titleCase, checkTWD, checkTTS, checkVI, mapLayerVisible, iconLayerVisible, } = rsaSettings;
@@ -1403,14 +1505,6 @@ function rsaInit() {
         if (localStorage) {
             localStorage.setItem("RSA_Settings", JSON.stringify(localSettings));
         }
-        // const serverSave = await WazeWrap.Remote.SaveSettings("RSA_Settings", localSettings);
-        // if (serverSave === null) {
-        //     console.warn("RSA: User PIN not set in WazeWrap tab");
-        // } else {
-        //     if (serverSave === false) {
-        //         console.error("RSA: Unable to save settings to server");
-        //     }
-        // }
     }
     function checkOptions() {
         const countries = sdk.DataModel.Countries.getAll();
@@ -1542,7 +1636,7 @@ function rsaInit() {
             WazeWrap.Alerts.error(GM_info.script.name, "You must have only 1 segment selected to use the shield editing menu");
         }
     }
-    function tryScan() {
+    async function tryScan() {
         if (!rsaSettings.enableScript)
             return;
         // Reset the array of objects that need names fixed
@@ -1561,7 +1655,7 @@ function rsaInit() {
             //     scanSeg(s);
             // }
             for (const s of sdk.DataModel.Segments.getAll()) {
-                processSeg(s);
+                await processSeg(s);
             }
         }
         // Scan all nodes on screen
@@ -1573,7 +1667,7 @@ function rsaInit() {
         }
     }
     const majorRoads = new Set([3, 4, 6, 7]);
-    function processSeg(seg) {
+    async function processSeg(seg) {
         if ((!rsaSettings.ShowRamps && seg.roadType === 4) ||
             (rsaSettings.mHPlus && !majorRoads.has(seg.roadType)))
             return;
@@ -1608,7 +1702,7 @@ function rsaInit() {
         // let oldStateName = W.model.states.getObjectById(cityID.stateID).attributes.name;
         const stateName = address.state === null ? "" : address.state.name;
         const countryID = address.country?.id;
-        const candidate = isSegmentCandidate(address, stateName, countryID);
+        const candidate = await isSegmentCandidate(address, stateName, countryID);
         // Display shield on map
         function checkDeclutterSettings(seg) {
             let result = false;
@@ -1688,11 +1782,11 @@ function rsaInit() {
             displayNodeIcons(node, guidance);
     }
     // Function written by kpouer to accommodate French conventions of shields being based on alt names
-    function isSegmentCandidate(address, stateName, countryId) {
-        let candidate = isStreetCandidate(address.street, stateName, countryId);
+    async function isSegmentCandidate(address, stateName, countryId) {
+        let candidate = await isStreetCandidate(address.street, stateName, countryId);
         if (!candidate.isCandidate && address.country !== null && address.country?.id !== undefined && CheckAltName.has(address.country.id)) {
             for (const altAddress of address.altStreets) {
-                candidate = isStreetCandidate(altAddress.street, stateName, countryId);
+                candidate = await isStreetCandidate(altAddress.street, stateName, countryId);
                 if (candidate.isCandidate) {
                     return candidate;
                 }
@@ -1700,7 +1794,7 @@ function rsaInit() {
         }
         return candidate;
     }
-    function isStreetCandidate(street, stateName, countryId) {
+    async function isStreetCandidate(street, stateName, countryId) {
         const info = { isCandidate: false, iconID: null };
         if (street === null || countryId === null || countryId === undefined) {
             return info;
@@ -1713,11 +1807,11 @@ function rsaInit() {
                 RoadAbbr[countryId] = false;
                 return info;
             }
-            loadCountryAbbr(countryId, CountryDataSheetInfo[countryId]);
+            await loadCountryAbbr(countryId, CountryDataSheetInfo[countryId], stateName);
         }
         // if (stateName === null) stateName = "";
         //Check to see if the country has states configured in RSA by looking for a key with nothing in it
-        if (street.name) {
+        if (street.name && typeof RoadAbbr[countryId] === "object") {
             const noStates = ("" in RoadAbbr[countryId]);
             const abbrvs = noStates
                 ? RoadAbbr[countryId][""]

--- a/WME-RSA.user.js
+++ b/WME-RSA.user.js
@@ -2,7 +2,7 @@
 // ==UserScript==
 // @name         WME Road Shield Assistant
 // @namespace    https://greasyfork.org/en/users/286957-skidooguy
-// @version      2025.12.22.001
+// @version      2026.06.11.001
 // @description  Adds shield information display to WME
 // @author       SkiDooGuy, jm6087, Karlsosha
 // @match        https://www.waze.com/editor*
@@ -11,14 +11,16 @@
 // @match        https://beta.waze.com/*/editor*
 // @exclude      https://www.waze.com/user/editor*
 // @require      https://greasyfork.org/scripts/24851-wazewrap/code/WazeWrap.js
-// @require      https://cdn.jsdelivr.net/npm/@turf/turf@7.3.1/turf.min.js
+// @require      https://cdn.jsdelivr.net/npm/@turf/turf@7/turf.min.js
 // @grant        GM_xmlhttpRequest
 // @grant        unsafeWindow
 // @connect      greasyfork.org
+// @connect      docs.google.com
 // @contributionURL https://github.com/WazeDev/Thank-The-Authors
 // ==/UserScript==
 /* global W */
 /* global WazeWrap */
+/* global turf */
 // import type { Node, Segment, SegmentAddress, Street, Turn, WmeSDK } from "wme-sdk-typings";
 // import type { Point, LineString, Position, Feature } from "geojson";
 // import * as turf from "@turf/turf";
@@ -26,12 +28,22 @@
 // import WazeWrap from "https://greasyfork.org/scripts/24851-wazewrap/code/WazeWrap.js";
 let sdk;
 unsafeWindow.SDK_INITIALIZED.then(() => {
-    if (!unsafeWindow.getWmeSdk) {
-        throw new Error("SDK is not installed");
+    try {
+        console.log("RSA: SDK_INITIALIZED event fired");
+        if (!unsafeWindow.getWmeSdk) {
+            throw new Error("SDK is not installed");
+        }
+        sdk = unsafeWindow.getWmeSdk({ scriptId: "wme-road-shield-assistant", scriptName: "WME Road Shield Assistant" });
+        console.log(`SDK v ${sdk.getSDKVersion()} on ${sdk.getWMEVersion()} initialized`);
+        sdk.Events.once({ eventName: "wme-ready" }).then(rsaInit).catch((e) => {
+            console.error("RSA: Error in rsaInit promise chain", e);
+        });
     }
-    sdk = unsafeWindow.getWmeSdk({ scriptId: "wme-road-shield-assistant", scriptName: "WME Road Shield Assistant" });
-    console.log(`SDK v ${sdk.getSDKVersion()} on ${sdk.getWMEVersion()} initialized`);
-    sdk.Events.once({ eventName: "wme-ready" }).then(rsaInit);
+    catch (e) {
+        console.error("RSA: Error in SDK initialization", e);
+    }
+}).catch((e) => {
+    console.error("RSA: Error in SDK_INITIALIZED promise", e);
 });
 function rsaInit() {
     if (!WazeWrap.Ready) {
@@ -43,9 +55,8 @@ function rsaInit() {
     const GF_LINK = "https://greasyfork.org/en/scripts/425050-wme-road-shield-assisstant";
     const FORUM_LINK = "https://www.waze.com/discuss/t/script-road-shield-assistant-rsa/227100";
     const RSA_UPDATE_NOTES = `<b>NEW:</b><br>
-    - Make Configurations External and Managed via Google Sheets<br>
+    - Remove Waze Wrap Remote Storage<br>
 <b>BUGFIXES:</b><br>
-    - Issue with Minor Highways or Greater<br>
 <b>KNOWN ISSUES:</b><br><br>`;
     let CountryID;
     (function (CountryID) {
@@ -351,6 +362,7 @@ function rsaInit() {
     const CountryDataSheetInfo = {};
     const RoadAbbr = {};
     let mainSheetLoaded = false;
+    const loadingCountries = new Set(); // Track which countries are currently being loaded
     const iconsAllowingNoText = new Set([
         2000, // Atlantic City Expy
         2079, // Garden State Parkway
@@ -706,10 +718,10 @@ function rsaInit() {
                     fillOpacity: 1,
                     fill: "black",
                     stroke: "black",
-                    fontColor: "green",
-                    labelOutlineColor: "white",
-                    labelOutlineWidth: 1,
-                    fontSize: 12,
+                    fontColor: "white",
+                    labelOutlineColor: "black",
+                    labelOutlineWidth: 2,
+                    fontSize: 14,
                     display: "grid",
                     label: "${shieldLabel}",
                     labelYOffset: "${shieldLabelYOffset}",
@@ -945,10 +957,13 @@ function rsaInit() {
         const $rsaFixWrapper = $('<div id="rsa-autoWrapper" class="toolbar-button ItemInactive" style="display:none;margin-right:5px;">');
         const $rsaFixInner = $('<div class="group-title toolbar-top-level-item-title rsa" style="margin:5px 0 0 15px;font-size:12px;">RSA Fix</div>');
         // WazeWrap.Interface.Tab('RSA', $rsaTab.html, setupOptions, 'RSA');
-        sdk.Sidebar.registerScriptTab().then((r) => {
+        sdk.Sidebar.registerScriptTab().then(async (r) => {
+            console.log("RSA: Registering sidebar tab");
             r.tabLabel.innerHTML = "RSA";
             r.tabPane.innerHTML = $rsaTab.html;
-            setupOptions();
+            console.log("RSA: Starting setupOptions");
+            await setupOptions();
+            console.log("RSA: setupOptions complete");
         });
         $(`<style type="text/css">${rsaCss}</style>`).appendTo("head");
         // $($rsaFixInner).appendTo($rsaFixWrapper);
@@ -1011,7 +1026,14 @@ function rsaInit() {
         checkOptions();
     }
     async function setupOptions() {
-        await loadSettings();
+        console.log("RSA: setupOptions started");
+        try {
+            await loadSettings();
+            console.log("RSA: loadSettings complete");
+        }
+        catch (e) {
+            console.error("RSA: Error in loadSettings", e);
+        }
         // Create OL layer for display
         sdk.Map.addLayer({
             layerName: rsaMapLayer.layerName,
@@ -1104,12 +1126,22 @@ function rsaInit() {
         // WazeWrap.Events.register('selectionchanged', null, tryScan);
         sdk.Events.on({ eventName: "wme-map-move-end", eventHandler: updateMap });
         sdk.Events.on({ eventName: "wme-map-zoom-changed", eventHandler: updateMap });
-        sdk.Shortcuts.createShortcut({
-            callback: addShieldClick,
-            description: "Activates the Add Shield Button",
-            shortcutId: "addShield",
-            shortcutKeys: "A+83",
-        });
+        const shortcutKeys = "A+83";
+        const keysInUse = sdk.Shortcuts.areShortcutKeysInUse({ shortcutKeys });
+        if (keysInUse) {
+            console.warn("RSA: Shortcut key A+S was already in use, registering addShield without a key binding.");
+        }
+        try {
+            sdk.Shortcuts.createShortcut({
+                callback: addShieldClick,
+                description: "Activates the Add Shield Button",
+                shortcutId: "addShield",
+                shortcutKeys: keysInUse ? null : shortcutKeys,
+            });
+        }
+        catch (e) {
+            console.error("RSA: Failed to register addShield shortcut:", e);
+        }
         // new WazeWrap.Interface.Shortcut('addShield',
         //                                 'Activates the Add Shield Button',
         //                                 'wmersa',
@@ -1221,73 +1253,149 @@ function rsaInit() {
         $("#rsa-resetSettings").attr("value", Strings[LANG].resetSettings);
         checkOptions();
     }
-    const apiKey = "AIzaSyDJaCD-PqytSPVrXZMLqI2UNIsTuy_yLRY";
     const mainRoadSheetID = "10RiokHwpEdcDu5AotXVBbesAzixDSCm9y5x44TRsToI";
-    async function loadCountryAbbr(countryId, sheetKey) {
-        if (!mainSheetLoaded)
+    const gvizCache = new Map(); // Cache parsed gviz responses by URL
+    async function parseGvizResponse(responseText) {
+        const match = responseText.match(/google\.visualization\.Query\.setResponse\(([\s\S]+)\);/);
+        if (!match) {
+            throw new Error("Failed to parse Google Sheet data");
+        }
+        return JSON.parse(match[1]);
+    }
+    async function gvizFetch(url) {
+        // Return cached parsed response if available
+        if (gvizCache.has(url)) {
+            console.log(`RSA: gvizFetch (cached) for URL: ${url}`);
+            return gvizCache.get(url);
+        }
+        console.log(`RSA: gvizFetch called with URL: ${url}`);
+        const promise = new Promise((resolve, reject) => {
+            GM_xmlhttpRequest({
+                method: "GET",
+                url: url,
+                timeout: 10000,
+                onload: (response) => {
+                    console.log(`RSA: gviz request to ${url} returned status ${response.status}`);
+                    if (response.status === 200) {
+                        try {
+                            const json = parseGvizResponse(response.responseText);
+                            resolve(json);
+                        }
+                        catch (e) {
+                            reject(e);
+                        }
+                    }
+                    else {
+                        const err = new Error(`HTTP ${response.status}: ${response.statusText} from ${url}`);
+                        console.error(`RSA: HTTP error`, err);
+                        reject(err);
+                    }
+                },
+                onerror: (err) => {
+                    console.error("RSA: gviz request error", err);
+                    reject(err);
+                },
+                ontimeout: () => {
+                    console.error("RSA: gviz request timeout");
+                    reject(new Error("Request timeout"));
+                },
+            });
+        });
+        // Cache the promise
+        gvizCache.set(url, promise);
+        return promise;
+    }
+    async function loadCountryAbbr(countryId, sheetKey, stateName) {
+        if (!mainSheetLoaded || loadingCountries.has(countryId))
             return;
-        // Load road abbreviation data
-        $.ajaxSetup({ async: false });
-        await $.getJSON(`https://sheets.googleapis.com/v4/spreadsheets/${sheetKey}?includeGridData=true&key=${apiKey}`)
-            .done(async (spreadSheet) => {
+        loadingCountries.add(countryId);
+        try {
             const countryWide = {};
-            let setCountry = false;
-            for (const sheet of spreadSheet.sheets) {
-                if (sheet.properties.title === "Reference")
-                    continue;
-                if (sheet.data[0].rowData.length <= 1)
-                    continue;
-                const stateWide = {};
-                for (const row of sheet.data[0].rowData) {
-                    if (row.values && row.values.length >= 2) {
-                        const matchingRegex = row.values[0].formattedValue;
-                        if (matchingRegex === "Matching Condition")
-                            continue;
-                        const shieldId = Number.parseInt(row.values[1].formattedValue, 10);
-                        stateWide[matchingRegex] = shieldId;
+            // Determine which sheets to load
+            let sheetsToLoad = [""]; // Always load country-wide (default) sheet
+            // If a specific state is requested, load only that state + country-wide
+            if (stateName) {
+                sheetsToLoad.push(stateName);
+            }
+            else {
+                // Initial load: just load country-wide sheet for fast startup
+                // State sheets will be loaded on-demand when needed
+                sheetsToLoad = [""];
+            }
+            // Load sheets in parallel
+            const sheetPromises = sheetsToLoad.map(async (sheetName) => {
+                try {
+                    const sheetUrl = sheetName
+                        ? `https://docs.google.com/spreadsheets/d/${sheetKey}/gviz/tq?tqx=out:json&sheet=${encodeURIComponent(sheetName)}`
+                        : `https://docs.google.com/spreadsheets/d/${sheetKey}/gviz/tq?tqx=out:json`;
+                    const json = await gvizFetch(sheetUrl);
+                    if (json.table && json.table.rows && json.table.rows.length > 0) {
+                        const sheetData = {};
+                        for (const row of json.table.rows) {
+                            if (!row.c || row.c.length < 2)
+                                continue;
+                            const abbr = row.c[0]?.v;
+                            const iconIdValue = row.c[1]?.v;
+                            if (!abbr || typeof abbr !== "string" || iconIdValue === null || iconIdValue === undefined)
+                                continue;
+                            const iconID = typeof iconIdValue === "number" ? iconIdValue : parseInt(iconIdValue, 10);
+                            sheetData[abbr] = iconID;
+                        }
+                        return { sheetName, sheetData, count: Object.keys(sheetData).length };
                     }
                 }
-                countryWide[sheet.properties.title] = stateWide;
-                setCountry = true;
+                catch (e) {
+                    // Sheet might not exist, skip it
+                }
+                return null;
+            });
+            const results = await Promise.allSettled(sheetPromises);
+            for (const result of results) {
+                if (result.status === "fulfilled" && result.value) {
+                    const { sheetName, sheetData } = result.value;
+                    countryWide[sheetName] = sheetData;
+                }
             }
-            if (setCountry)
+            if (Object.keys(countryWide).length > 0 && Object.values(countryWide).some(state => Object.keys(state).length > 0)) {
                 RoadAbbr[countryId] = countryWide;
-        }).fail(() => {
-            console.error("RSA: Unable to load road abbreviation data from Google Sheets");
-        });
-        $.ajaxSetup({ async: true });
+            }
+        }
+        catch (e) {
+            console.error("RSA: Unable to load road abbreviation data from Google Sheets", e);
+        }
+        finally {
+            loadingCountries.delete(countryId);
+        }
     }
-    function loadMainRoadAbbr() {
-        $.getJSON(`https://sheets.googleapis.com/v4/spreadsheets/${mainRoadSheetID}?includeGridData=true&key=${apiKey}`, (spreadSheet) => {
-            for (const sheet of spreadSheet.sheets) {
-                if (sheet.properties.title === "CountryData") {
-                    for (const row of sheet.data[0].rowData) {
-                        if (row.values && row.values.length >= 2) {
-                            const country = row.values[0].formattedValue;
-                            if (country === "Country")
-                                continue;
-                            const countryCode = Number.parseInt(row.values[1].formattedValue, 10);
-                            if (row.values.length >= 3) {
-                                const sheetKey = row.values[2].formattedValue;
-                                CountryDataSheetInfo[countryCode] = sheetKey;
-                            }
-                        }
+    async function loadMainRoadAbbr() {
+        try {
+            const gvizUrl = `https://docs.google.com/spreadsheets/d/${mainRoadSheetID}/gviz/tq?tqx=out:json&sheet=${encodeURIComponent("CountryData")}`;
+            const json = await gvizFetch(gvizUrl);
+            if (json.table && json.table.rows) {
+                for (const row of json.table.rows) {
+                    if (!row.c || row.c.length < 3)
+                        continue;
+                    const country = row.c[0]?.v;
+                    if (!country || country === "Country")
+                        continue;
+                    const countryCode = parseInt(row.c[1]?.v ?? "0", 10);
+                    const sheetKey = row.c[2]?.v;
+                    if (countryCode && sheetKey) {
+                        CountryDataSheetInfo[countryCode] = sheetKey;
                     }
                 }
             }
             mainSheetLoaded = true;
-        }).done(() => {
             console.log("RSA: Main Road Abbreviations are Loaded");
-        }).fail(() => {
-            console.error("RSA: Unable to load road abbreviation data from Google Sheets");
-        });
+        }
+        catch (e) {
+            console.error("RSA: Unable to load road abbreviation data from Google Sheets", e);
+        }
     }
     async function loadSettings() {
+        console.log("RSA: loadSettings started");
         const localSettings = JSON.parse(localStorage.getItem("RSA_Settings"));
-        const serverSettings = await WazeWrap.Remote.RetrieveSettings("RSA_Settings");
-        if (!serverSettings) {
-            console.error("RSA: Error communicating with WW settings server");
-        }
+        console.log("RSA: localSettings parsed, calling loadMainRoadAbbr");
         const defaultSettings = {
             lastSaveAction: 0,
             enableScript: true,
@@ -1325,14 +1433,7 @@ function rsaInit() {
             iconLayerVisible: false,
         };
         rsaSettings = $.extend({}, defaultSettings, localSettings);
-        if (serverSettings && serverSettings.lastSaveAction > rsaSettings.lastSaveAction) {
-            $.extend(rsaSettings, serverSettings);
-            // console.log('RSA: server settings used');
-        }
-        else {
-            // console.log('RSA: local settings used');
-        }
-        loadMainRoadAbbr();
+        await loadMainRoadAbbr();
     }
     async function saveSettings() {
         const { enableScript, HighSegShields, ShowSegShields, SegShieldMissing, SegShieldError, HighNodeShields, ShowNodeShields, ShowExitShields, SegHasDir, SegInvDir, ShowTurnTTS, AlertTurnTTS, ShowTowards, ShowVisualInst, NodeShieldMissing, HighSegClr, MissSegClr, ErrSegClr, HighNodeClr, MissNodeClr, SegHasDirClr, SegInvDirClr, TitleCaseClr, TitleCaseSftClr, ShowRamps, AlternativeShields, mHPlus, titleCase, checkTWD, checkTTS, checkVI, mapLayerVisible, iconLayerVisible, } = rsaSettings;
@@ -1403,15 +1504,6 @@ function rsaInit() {
         rsaSettings = localSettings;
         if (localStorage) {
             localStorage.setItem("RSA_Settings", JSON.stringify(localSettings));
-        }
-        const serverSave = await WazeWrap.Remote.SaveSettings("RSA_Settings", localSettings);
-        if (serverSave === null) {
-            console.warn("RSA: User PIN not set in WazeWrap tab");
-        }
-        else {
-            if (serverSave === false) {
-                console.error("RSA: Unable to save settings to server");
-            }
         }
     }
     function checkOptions() {
@@ -1544,7 +1636,7 @@ function rsaInit() {
             WazeWrap.Alerts.error(GM_info.script.name, "You must have only 1 segment selected to use the shield editing menu");
         }
     }
-    function tryScan() {
+    async function tryScan() {
         if (!rsaSettings.enableScript)
             return;
         // Reset the array of objects that need names fixed
@@ -1563,7 +1655,7 @@ function rsaInit() {
             //     scanSeg(s);
             // }
             for (const s of sdk.DataModel.Segments.getAll()) {
-                processSeg(s);
+                await processSeg(s);
             }
         }
         // Scan all nodes on screen
@@ -1575,7 +1667,7 @@ function rsaInit() {
         }
     }
     const majorRoads = new Set([3, 4, 6, 7]);
-    function processSeg(seg) {
+    async function processSeg(seg) {
         if ((!rsaSettings.ShowRamps && seg.roadType === 4) ||
             (rsaSettings.mHPlus && !majorRoads.has(seg.roadType)))
             return;
@@ -1610,7 +1702,7 @@ function rsaInit() {
         // let oldStateName = W.model.states.getObjectById(cityID.stateID).attributes.name;
         const stateName = address.state === null ? "" : address.state.name;
         const countryID = address.country?.id;
-        const candidate = isSegmentCandidate(address, stateName, countryID);
+        const candidate = await isSegmentCandidate(address, stateName, countryID);
         // Display shield on map
         function checkDeclutterSettings(seg) {
             let result = false;
@@ -1690,11 +1782,11 @@ function rsaInit() {
             displayNodeIcons(node, guidance);
     }
     // Function written by kpouer to accommodate French conventions of shields being based on alt names
-    function isSegmentCandidate(address, stateName, countryId) {
-        let candidate = isStreetCandidate(address.street, stateName, countryId);
+    async function isSegmentCandidate(address, stateName, countryId) {
+        let candidate = await isStreetCandidate(address.street, stateName, countryId);
         if (!candidate.isCandidate && address.country !== null && address.country?.id !== undefined && CheckAltName.has(address.country.id)) {
             for (const altAddress of address.altStreets) {
-                candidate = isStreetCandidate(altAddress.street, stateName, countryId);
+                candidate = await isStreetCandidate(altAddress.street, stateName, countryId);
                 if (candidate.isCandidate) {
                     return candidate;
                 }
@@ -1702,7 +1794,7 @@ function rsaInit() {
         }
         return candidate;
     }
-    function isStreetCandidate(street, stateName, countryId) {
+    async function isStreetCandidate(street, stateName, countryId) {
         const info = { isCandidate: false, iconID: null };
         if (street === null || countryId === null || countryId === undefined) {
             return info;
@@ -1715,11 +1807,11 @@ function rsaInit() {
                 RoadAbbr[countryId] = false;
                 return info;
             }
-            loadCountryAbbr(countryId, CountryDataSheetInfo[countryId]);
+            await loadCountryAbbr(countryId, CountryDataSheetInfo[countryId], stateName);
         }
         // if (stateName === null) stateName = "";
         //Check to see if the country has states configured in RSA by looking for a key with nothing in it
-        if (street.name) {
+        if (street.name && typeof RoadAbbr[countryId] === "object") {
             const noStates = ("" in RoadAbbr[countryId]);
             const abbrvs = noStates
                 ? RoadAbbr[countryId][""]

--- a/WME-RSA.user.ts
+++ b/WME-RSA.user.ts
@@ -1404,10 +1404,10 @@ function rsaInit() {
     }
     async function loadSettings() {
         const localSettings = JSON.parse(<string>localStorage.getItem("RSA_Settings"));
-        const serverSettings = await WazeWrap.Remote.RetrieveSettings("RSA_Settings");
-        if (!serverSettings) {
-            console.error("RSA: Error communicating with WW settings server");
-        }
+        // const serverSettings = await WazeWrap.Remote.RetrieveSettings("RSA_Settings");
+        // if (!serverSettings) {
+        //     console.error("RSA: Error communicating with WW settings server");
+        // }
 
         const defaultSettings: RSASettings = {
             lastSaveAction: 0,
@@ -1447,12 +1447,12 @@ function rsaInit() {
         };
 
         rsaSettings = $.extend({}, defaultSettings, localSettings);
-        if (serverSettings && serverSettings.lastSaveAction > rsaSettings.lastSaveAction) {
-            $.extend(rsaSettings, serverSettings);
-            // console.log('RSA: server settings used');
-        } else {
-            // console.log('RSA: local settings used');
-        }
+        // if (serverSettings && serverSettings.lastSaveAction > rsaSettings.lastSaveAction) {
+        //     $.extend(rsaSettings, serverSettings);
+        //     // console.log('RSA: server settings used');
+        // } else {
+        //     // console.log('RSA: local settings used');
+        // }
 
         loadMainRoadAbbr();
     }
@@ -1565,15 +1565,15 @@ function rsaInit() {
         if (localStorage) {
             localStorage.setItem("RSA_Settings", JSON.stringify(localSettings));
         }
-        const serverSave = await WazeWrap.Remote.SaveSettings("RSA_Settings", localSettings);
+        // const serverSave = await WazeWrap.Remote.SaveSettings("RSA_Settings", localSettings);
 
-        if (serverSave === null) {
-            console.warn("RSA: User PIN not set in WazeWrap tab");
-        } else {
-            if (serverSave === false) {
-                console.error("RSA: Unable to save settings to server");
-            }
-        }
+        // if (serverSave === null) {
+        //     console.warn("RSA: User PIN not set in WazeWrap tab");
+        // } else {
+        //     if (serverSave === false) {
+        //         console.error("RSA: Unable to save settings to server");
+        //     }
+        // }
     }
 
     function checkOptions() {

--- a/WME-RSA.user.ts
+++ b/WME-RSA.user.ts
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         WME Road Shield Assistant
 // @namespace    https://greasyfork.org/en/users/286957-skidooguy
-// @version      2025.12.22.001
+// @version      2026.04.19.001
 // @description  Adds shield information display to WME
 // @author       SkiDooGuy, jm6087, Karlsosha
 // @match        https://www.waze.com/editor*
@@ -10,7 +10,6 @@
 // @match        https://beta.waze.com/*/editor*
 // @exclude      https://www.waze.com/user/editor*
 // @require      https://greasyfork.org/scripts/24851-wazewrap/code/WazeWrap.js
-// @require      https://cdn.jsdelivr.net/npm/@turf/turf@7.3.1/turf.min.js
 // @grant        GM_xmlhttpRequest
 // @grant        unsafeWindow
 // @connect      greasyfork.org
@@ -19,6 +18,7 @@
 
 /* global W */
 /* global WazeWrap */
+/* global turf */
 
 // import type { Node, Segment, SegmentAddress, Street, Turn, WmeSDK } from "wme-sdk-typings";
 // import type { Point, LineString, Position, Feature } from "geojson";
@@ -48,9 +48,8 @@ function rsaInit() {
     const GF_LINK = "https://greasyfork.org/en/scripts/425050-wme-road-shield-assisstant";
     const FORUM_LINK = "https://www.waze.com/discuss/t/script-road-shield-assistant-rsa/227100";
     const RSA_UPDATE_NOTES = `<b>NEW:</b><br>
-    - Make Configurations External and Managed via Google Sheets<br>
+    - Remove Waze Wrap Remote Storage<br>
 <b>BUGFIXES:</b><br>
-    - Issue with Minor Highways or Greater<br>
 <b>KNOWN ISSUES:</b><br><br>`;
 
     enum CountryID {

--- a/WME-RSA.user.ts
+++ b/WME-RSA.user.ts
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         WME Road Shield Assistant
 // @namespace    https://greasyfork.org/en/users/286957-skidooguy
-// @version      2026.04.19.001
+// @version      2026.04.23.001
 // @description  Adds shield information display to WME
 // @author       SkiDooGuy, jm6087, Karlsosha
 // @match        https://www.waze.com/editor*
@@ -10,6 +10,7 @@
 // @match        https://beta.waze.com/*/editor*
 // @exclude      https://www.waze.com/user/editor*
 // @require      https://greasyfork.org/scripts/24851-wazewrap/code/WazeWrap.js
+// @require      https://cdn.jsdelivr.net/npm/@turf/turf@7/turf.min.js
 // @grant        GM_xmlhttpRequest
 // @grant        unsafeWindow
 // @connect      greasyfork.org

--- a/WME-RSA.user.ts
+++ b/WME-RSA.user.ts
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         WME Road Shield Assistant
 // @namespace    https://greasyfork.org/en/users/286957-skidooguy
-// @version      2025.12.22.001
+// @version      2025.03.03.001
 // @description  Adds shield information display to WME
 // @author       SkiDooGuy, jm6087, Karlsosha
 // @match        https://www.waze.com/editor*
@@ -1224,12 +1224,30 @@ function rsaInit() {
         sdk.Events.on({ eventName: "wme-map-move-end", eventHandler: updateMap });
         sdk.Events.on({ eventName: "wme-map-zoom-changed", eventHandler: updateMap });
 
-        sdk.Shortcuts.createShortcut({
-            callback: addShieldClick,
-            description: "Activates the Add Shield Button",
-            shortcutId: "addShield",
-            shortcutKeys: "A+83",
-        });
+        try {
+            sdk.Shortcuts.createShortcut({
+                callback: addShieldClick,
+                description: "Activates the Add Shield Button",
+                shortcutId: "addShield",
+                shortcutKeys: "A+83",
+            });
+        } catch (e) {
+            if (e instanceof Error && e.message.includes("already in use")) {
+                console.warn("RSA: Shortcut key A+S was already in use, registering addShield without a key binding.");
+                try {
+                    sdk.Shortcuts.createShortcut({
+                        callback: addShieldClick,
+                        description: "Activates the Add Shield Button",
+                        shortcutId: "addShield",
+                        shortcutKeys: null,
+                    });
+                } catch (retryError) {
+                    console.error("RSA: Failed to register addShield shortcut even with null keys:", retryError);
+                }
+            } else {
+                console.error("RSA: Failed to register addShield shortcut:", e);
+            }
+        }
         // new WazeWrap.Interface.Shortcut('addShield',
         //                                 'Activates the Add Shield Button',
         //                                 'wmersa',

--- a/WME-RSA.user.ts
+++ b/WME-RSA.user.ts
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         WME Road Shield Assistant
 // @namespace    https://greasyfork.org/en/users/286957-skidooguy
-// @version      2026.04.23.001
+// @version      2026.06.11.001
 // @description  Adds shield information display to WME
 // @author       SkiDooGuy, jm6087, Karlsosha
 // @match        https://www.waze.com/editor*
@@ -14,6 +14,7 @@
 // @grant        GM_xmlhttpRequest
 // @grant        unsafeWindow
 // @connect      greasyfork.org
+// @connect      docs.google.com
 // @contributionURL https://github.com/WazeDev/Thank-The-Authors
 // ==/UserScript==
 
@@ -29,13 +30,22 @@
 
 let sdk: WmeSDK;
 unsafeWindow.SDK_INITIALIZED.then(() => {
-    if (!unsafeWindow.getWmeSdk) {
-        throw new Error("SDK is not installed");
-    }
-    sdk = unsafeWindow.getWmeSdk({ scriptId: "wme-road-shield-assistant", scriptName: "WME Road Shield Assistant" });
+    try {
+        console.log("RSA: SDK_INITIALIZED event fired");
+        if (!unsafeWindow.getWmeSdk) {
+            throw new Error("SDK is not installed");
+        }
+        sdk = unsafeWindow.getWmeSdk({ scriptId: "wme-road-shield-assistant", scriptName: "WME Road Shield Assistant" });
 
-    console.log(`SDK v ${sdk.getSDKVersion()} on ${sdk.getWMEVersion()} initialized`);
-    sdk.Events.once({ eventName: "wme-ready" }).then(rsaInit);
+        console.log(`SDK v ${sdk.getSDKVersion()} on ${sdk.getWMEVersion()} initialized`);
+        sdk.Events.once({ eventName: "wme-ready" }).then(rsaInit).catch((e: any) => {
+            console.error("RSA: Error in rsaInit promise chain", e);
+        });
+    } catch (e: any) {
+        console.error("RSA: Error in SDK initialization", e);
+    }
+}).catch((e: any) => {
+    console.error("RSA: Error in SDK_INITIALIZED promise", e);
 });
 
 function rsaInit() {
@@ -424,13 +434,14 @@ function rsaInit() {
     }
     type RoadInfo = Record<string, number | Set<number>>;
     type StateRoadInfo = Record<string, RoadInfo>;
-    type CountryRoadInfo = Record<number, StateRoadInfo>;
+    type CountryRoadInfo = Record<number, StateRoadInfo | false>;
     type CountryDataSheetMap = Record<number, string>;
 
     const CountryDataSheetInfo: CountryDataSheetMap = {};
 
     const RoadAbbr: CountryRoadInfo = {};
     let mainSheetLoaded = false;
+    const loadingCountries = new Set<number>();  // Track which countries are currently being loaded
     const iconsAllowingNoText = new Set<number>([
         2000, // Atlantic City Expy
         2079, // Garden State Parkway
@@ -1041,10 +1052,13 @@ function rsaInit() {
         );
 
         // WazeWrap.Interface.Tab('RSA', $rsaTab.html, setupOptions, 'RSA');
-        sdk.Sidebar.registerScriptTab().then((r) => {
+        sdk.Sidebar.registerScriptTab().then(async (r: any) => {
+            console.log("RSA: Registering sidebar tab");
             r.tabLabel.innerHTML = "RSA";
             r.tabPane.innerHTML = $rsaTab.html;
-            setupOptions();
+            console.log("RSA: Starting setupOptions");
+            await setupOptions();
+            console.log("RSA: setupOptions complete");
         });
         $(`<style type="text/css">${rsaCss}</style>`).appendTo("head");
         // $($rsaFixInner).appendTo($rsaFixWrapper);
@@ -1125,7 +1139,13 @@ function rsaInit() {
     }
 
     async function setupOptions() {
-        await loadSettings();
+        console.log("RSA: setupOptions started");
+        try {
+            await loadSettings();
+            console.log("RSA: loadSettings complete");
+        } catch (e) {
+            console.error("RSA: Error in loadSettings", e);
+        }
 
         // Create OL layer for display
 
@@ -1224,12 +1244,23 @@ function rsaInit() {
         sdk.Events.on({ eventName: "wme-map-move-end", eventHandler: updateMap });
         sdk.Events.on({ eventName: "wme-map-zoom-changed", eventHandler: updateMap });
 
-        sdk.Shortcuts.createShortcut({
-            callback: addShieldClick,
-            description: "Activates the Add Shield Button",
-            shortcutId: "addShield",
-            shortcutKeys: "A+83",
-        });
+        const shortcutKeys = "A+83";
+        const keysInUse = sdk.Shortcuts.areShortcutKeysInUse({ shortcutKeys });
+
+        if (keysInUse) {
+            console.warn("RSA: Shortcut key A+S was already in use, registering addShield without a key binding.");
+        }
+
+        try {
+            sdk.Shortcuts.createShortcut({
+                callback: addShieldClick,
+                description: "Activates the Add Shield Button",
+                shortcutId: "addShield",
+                shortcutKeys: keysInUse ? null : shortcutKeys,
+            });
+        } catch (e) {
+            console.error("RSA: Failed to register addShield shortcut:", e);
+        }
         // new WazeWrap.Interface.Shortcut('addShield',
         //                                 'Activates the Add Shield Button',
         //                                 'wmersa',
@@ -1345,70 +1376,161 @@ function rsaInit() {
         checkOptions();
     }
 
-    const apiKey = "AIzaSyDJaCD-PqytSPVrXZMLqI2UNIsTuy_yLRY";
     const mainRoadSheetID = "10RiokHwpEdcDu5AotXVBbesAzixDSCm9y5x44TRsToI";
-    async function loadCountryAbbr(countryId: number, sheetKey: string) {
-        if(!mainSheetLoaded) return;
-        // Load road abbreviation data
-        $.ajaxSetup({ async: false})
-        await $.getJSON(`https://sheets.googleapis.com/v4/spreadsheets/${sheetKey}?includeGridData=true&key=${apiKey}`)
-        .done(async (spreadSheet) => {
-            const countryWide: StateRoadInfo = {};
-            let setCountry = false;
-            for (const sheet of spreadSheet.sheets) {
-                if (sheet.properties.title === "Reference") continue;
-                if(sheet.data[0].rowData.length <= 1) continue;
-                const stateWide: RoadInfo = {};
-                for (const row of sheet.data[0].rowData) {
-                    if (row.values && row.values.length >= 2) {
-                        const matchingRegex = row.values[0].formattedValue;
-                        if (matchingRegex === "Matching Condition") continue;
-                        const shieldId = Number.parseInt(row.values[1].formattedValue, 10);
-                        stateWide[matchingRegex] = shieldId;
-                    }
-                }
-                countryWide[sheet.properties.title] = stateWide;
-                setCountry = true;
-            }
-            if(setCountry) RoadAbbr[countryId] = countryWide;
-        }).fail(() => {
-            console.error("RSA: Unable to load road abbreviation data from Google Sheets");
-        });
-        $.ajaxSetup({ async: true })
+    const gvizCache = new Map<string, Promise<any>>();  // Cache parsed gviz responses by URL
 
+    async function parseGvizResponse(responseText: string) {
+        const match = responseText.match(/google\.visualization\.Query\.setResponse\(([\s\S]+)\);/);
+        if (!match) {
+            throw new Error("Failed to parse Google Sheet data");
+        }
+        return JSON.parse(match[1]);
     }
 
-    function loadMainRoadAbbr() {
-        $.getJSON(`https://sheets.googleapis.com/v4/spreadsheets/${mainRoadSheetID}?includeGridData=true&key=${apiKey}`, (spreadSheet) => {
-            for(const sheet of spreadSheet.sheets) {
-                if(sheet.properties.title === "CountryData") {
-                    for(const row of sheet.data[0].rowData) {
-                        if(row.values && row.values.length >= 2) {
-                            const country = row.values[0].formattedValue;
-                            if(country === "Country") continue;
-                            const countryCode = Number.parseInt(row.values[1].formattedValue, 10);
-                            if(row.values.length >= 3) {
-                                const sheetKey = row.values[2].formattedValue;
-                                CountryDataSheetInfo[countryCode] = sheetKey;
-                            }
+    async function gvizFetch(url: string): Promise<any> {
+        // Return cached parsed response if available
+        if (gvizCache.has(url)) {
+            console.log(`RSA: gvizFetch (cached) for URL: ${url}`);
+            return gvizCache.get(url)!;
+        }
+
+        console.log(`RSA: gvizFetch called with URL: ${url}`);
+        const promise = new Promise<any>((resolve, reject) => {
+            GM_xmlhttpRequest({
+                method: "GET",
+                url: url,
+                timeout: 10000,
+                onload: (response) => {
+                    console.log(`RSA: gviz request to ${url} returned status ${response.status}`);
+                    if (response.status === 200) {
+                        try {
+                            const json = parseGvizResponse(response.responseText);
+                            resolve(json);
+                        } catch (e) {
+                            reject(e);
                         }
+                    } else {
+                        const err = new Error(`HTTP ${response.status}: ${response.statusText} from ${url}`);
+                        console.error(`RSA: HTTP error`, err);
+                        reject(err);
+                    }
+                },
+                onerror: (err) => {
+                    console.error("RSA: gviz request error", err);
+                    reject(err);
+                },
+                ontimeout: () => {
+                    console.error("RSA: gviz request timeout");
+                    reject(new Error("Request timeout"));
+                },
+            });
+        });
+
+        // Cache the promise
+        gvizCache.set(url, promise);
+        return promise;
+    }
+
+    async function loadCountryAbbr(countryId: number, sheetKey: string, stateName?: string) {
+        if (!mainSheetLoaded || loadingCountries.has(countryId)) return;
+
+        loadingCountries.add(countryId);
+
+        try {
+            const countryWide: StateRoadInfo = {};
+
+            // Determine which sheets to load
+            let sheetsToLoad: string[] = [""];  // Always load country-wide (default) sheet
+
+            // If a specific state is requested, load only that state + country-wide
+            if (stateName) {
+                sheetsToLoad.push(stateName);
+            } else {
+                // Initial load: just load country-wide sheet for fast startup
+                // State sheets will be loaded on-demand when needed
+                sheetsToLoad = [""];
+            }
+
+            // Load sheets in parallel
+            const sheetPromises = sheetsToLoad.map(async (sheetName) => {
+                try {
+                    const sheetUrl = sheetName
+                        ? `https://docs.google.com/spreadsheets/d/${sheetKey}/gviz/tq?tqx=out:json&sheet=${encodeURIComponent(sheetName)}`
+                        : `https://docs.google.com/spreadsheets/d/${sheetKey}/gviz/tq?tqx=out:json`;
+
+                    const json = await gvizFetch(sheetUrl);
+
+                    if (json.table && json.table.rows && json.table.rows.length > 0) {
+                        const sheetData: Record<string, number> = {};
+
+                        for (const row of json.table.rows) {
+                            if (!row.c || row.c.length < 2) continue;
+
+                            const abbr = row.c[0]?.v;
+                            const iconIdValue = row.c[1]?.v;
+
+                            if (!abbr || typeof abbr !== "string" || iconIdValue === null || iconIdValue === undefined) continue;
+
+                            const iconID = typeof iconIdValue === "number" ? iconIdValue : parseInt(iconIdValue, 10);
+                            sheetData[abbr] = iconID;
+                        }
+                        return { sheetName, sheetData, count: Object.keys(sheetData).length };
+                    }
+                } catch (e) {
+                    // Sheet might not exist, skip it
+                }
+                return null;
+            });
+
+            const results = await Promise.allSettled(sheetPromises);
+            for (const result of results) {
+                if (result.status === "fulfilled" && result.value) {
+                    const { sheetName, sheetData } = result.value;
+                    countryWide[sheetName] = sheetData;
+                }
+            }
+
+            if (Object.keys(countryWide).length > 0 && Object.values(countryWide).some(state => Object.keys(state).length > 0)) {
+                RoadAbbr[countryId] = countryWide;
+            }
+        } catch (e) {
+            console.error("RSA: Unable to load road abbreviation data from Google Sheets", e);
+        } finally {
+            loadingCountries.delete(countryId);
+        }
+    }
+
+    async function loadMainRoadAbbr() {
+        try {
+            const gvizUrl = `https://docs.google.com/spreadsheets/d/${mainRoadSheetID}/gviz/tq?tqx=out:json&sheet=${encodeURIComponent("CountryData")}`;
+            const json = await gvizFetch(gvizUrl);
+
+            if (json.table && json.table.rows) {
+                for (const row of json.table.rows) {
+                    if (!row.c || row.c.length < 3) continue;
+
+                    const country = row.c[0]?.v;
+                    if (!country || country === "Country") continue;
+
+                    const countryCode = parseInt(row.c[1]?.v ?? "0", 10);
+                    const sheetKey = row.c[2]?.v;
+
+                    if (countryCode && sheetKey) {
+                        CountryDataSheetInfo[countryCode] = sheetKey;
                     }
                 }
             }
+
             mainSheetLoaded = true;
-        }).done(() => {
             console.log("RSA: Main Road Abbreviations are Loaded");
-        }).fail(() => {
-            console.error("RSA: Unable to load road abbreviation data from Google Sheets");
-        });
+        } catch (e) {
+            console.error("RSA: Unable to load road abbreviation data from Google Sheets", e);
+        }
     }
     async function loadSettings() {
+        console.log("RSA: loadSettings started");
         const localSettings = JSON.parse(<string>localStorage.getItem("RSA_Settings"));
-        // const serverSettings = await WazeWrap.Remote.RetrieveSettings("RSA_Settings");
-        // if (!serverSettings) {
-        //     console.error("RSA: Error communicating with WW settings server");
-        // }
-
+        console.log("RSA: localSettings parsed, calling loadMainRoadAbbr");
         const defaultSettings: RSASettings = {
             lastSaveAction: 0,
             enableScript: true,
@@ -1447,14 +1569,7 @@ function rsaInit() {
         };
 
         rsaSettings = $.extend({}, defaultSettings, localSettings);
-        // if (serverSettings && serverSettings.lastSaveAction > rsaSettings.lastSaveAction) {
-        //     $.extend(rsaSettings, serverSettings);
-        //     // console.log('RSA: server settings used');
-        // } else {
-        //     // console.log('RSA: local settings used');
-        // }
-
-        loadMainRoadAbbr();
+        await loadMainRoadAbbr();
     }
 
     async function saveSettings() {
@@ -1565,15 +1680,6 @@ function rsaInit() {
         if (localStorage) {
             localStorage.setItem("RSA_Settings", JSON.stringify(localSettings));
         }
-        // const serverSave = await WazeWrap.Remote.SaveSettings("RSA_Settings", localSettings);
-
-        // if (serverSave === null) {
-        //     console.warn("RSA: User PIN not set in WazeWrap tab");
-        // } else {
-        //     if (serverSave === false) {
-        //         console.error("RSA: Unable to save settings to server");
-        //     }
-        // }
     }
 
     function checkOptions() {
@@ -1717,7 +1823,7 @@ function rsaInit() {
         }
     }
 
-    function tryScan() {
+    async function tryScan() {
         if (!rsaSettings.enableScript) return;
 
         // Reset the array of objects that need names fixed
@@ -1738,7 +1844,7 @@ function rsaInit() {
             //     scanSeg(s);
             // }
             for (const s of sdk.DataModel.Segments.getAll()) {
-                processSeg(s);
+                await processSeg(s);
             }
         }
         // Scan all nodes on screen
@@ -1751,7 +1857,7 @@ function rsaInit() {
     }
 
     const majorRoads = new Set<number>([3, 4, 6, 7]);
-    function processSeg(seg: Segment) {
+    async function processSeg(seg: Segment) {
         if (
             (!rsaSettings.ShowRamps && seg.roadType === 4) ||
             (rsaSettings.mHPlus && !majorRoads.has(seg.roadType))
@@ -1790,7 +1896,7 @@ function rsaInit() {
         // let oldStateName = W.model.states.getObjectById(cityID.stateID).attributes.name;
         const stateName: string = address.state === null ? "" : address.state.name;
         const countryID = address.country?.id;
-        const candidate: Candidate = isSegmentCandidate(address, stateName, countryID);
+        const candidate: Candidate = await isSegmentCandidate(address, stateName, countryID);
 
         // Display shield on map
         function checkDeclutterSettings(seg: Segment): boolean {
@@ -1877,11 +1983,11 @@ function rsaInit() {
     }
 
     // Function written by kpouer to accommodate French conventions of shields being based on alt names
-    function isSegmentCandidate(address: SegmentAddress, stateName: string, countryId: number | null | undefined) {
-        let candidate = isStreetCandidate(address.street, stateName, countryId);
+    async function isSegmentCandidate(address: SegmentAddress, stateName: string, countryId: number | null | undefined): Promise<Candidate> {
+        let candidate = await isStreetCandidate(address.street, stateName, countryId);
         if (!candidate.isCandidate && address.country !== null && address.country?.id !== undefined && CheckAltName.has(address.country.id)) {
             for (const altAddress of address.altStreets) {
-                candidate = isStreetCandidate(altAddress.street, stateName, countryId);
+                candidate = await isStreetCandidate(altAddress.street, stateName, countryId);
                 if (candidate.isCandidate) {
                     return candidate;
                 }
@@ -1890,7 +1996,7 @@ function rsaInit() {
         return candidate;
     }
 
-    function isStreetCandidate(street: Street | null, stateName: string, countryId: number | null | undefined): Candidate {
+    async function isStreetCandidate(street: Street | null, stateName: string, countryId: number | null | undefined): Promise<Candidate> {
         const info: Candidate = { isCandidate: false, iconID: null };
 
         if (street === null || countryId === null || countryId === undefined) {
@@ -1905,12 +2011,12 @@ function rsaInit() {
                 RoadAbbr[countryId] = false;
                 return info;
             }
-            loadCountryAbbr(countryId, CountryDataSheetInfo[countryId]);
+            await loadCountryAbbr(countryId, CountryDataSheetInfo[countryId], stateName);
         }
         // if (stateName === null) stateName = "";
 
         //Check to see if the country has states configured in RSA by looking for a key with nothing in it
-        if (street.name) {
+        if (street.name && typeof RoadAbbr[countryId] === "object") {
             const noStates: boolean = ("" in RoadAbbr[countryId]);
             const abbrvs = noStates
                 ? RoadAbbr[countryId][""]

--- a/WME-RSA.user.ts
+++ b/WME-RSA.user.ts
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         WME Road Shield Assistant
 // @namespace    https://greasyfork.org/en/users/286957-skidooguy
-// @version      2025.03.03.001
+// @version      2026.06.11.001
 // @description  Adds shield information display to WME
 // @author       SkiDooGuy, jm6087, Karlsosha
 // @match        https://www.waze.com/editor*
@@ -10,15 +10,17 @@
 // @match        https://beta.waze.com/*/editor*
 // @exclude      https://www.waze.com/user/editor*
 // @require      https://greasyfork.org/scripts/24851-wazewrap/code/WazeWrap.js
-// @require      https://cdn.jsdelivr.net/npm/@turf/turf@7.3.1/turf.min.js
+// @require      https://cdn.jsdelivr.net/npm/@turf/turf@7/turf.min.js
 // @grant        GM_xmlhttpRequest
 // @grant        unsafeWindow
 // @connect      greasyfork.org
+// @connect      docs.google.com
 // @contributionURL https://github.com/WazeDev/Thank-The-Authors
 // ==/UserScript==
 
 /* global W */
 /* global WazeWrap */
+/* global turf */
 
 // import type { Node, Segment, SegmentAddress, Street, Turn, WmeSDK } from "wme-sdk-typings";
 // import type { Point, LineString, Position, Feature } from "geojson";
@@ -28,13 +30,22 @@
 
 let sdk: WmeSDK;
 unsafeWindow.SDK_INITIALIZED.then(() => {
-    if (!unsafeWindow.getWmeSdk) {
-        throw new Error("SDK is not installed");
-    }
-    sdk = unsafeWindow.getWmeSdk({ scriptId: "wme-road-shield-assistant", scriptName: "WME Road Shield Assistant" });
+    try {
+        console.log("RSA: SDK_INITIALIZED event fired");
+        if (!unsafeWindow.getWmeSdk) {
+            throw new Error("SDK is not installed");
+        }
+        sdk = unsafeWindow.getWmeSdk({ scriptId: "wme-road-shield-assistant", scriptName: "WME Road Shield Assistant" });
 
-    console.log(`SDK v ${sdk.getSDKVersion()} on ${sdk.getWMEVersion()} initialized`);
-    sdk.Events.once({ eventName: "wme-ready" }).then(rsaInit);
+        console.log(`SDK v ${sdk.getSDKVersion()} on ${sdk.getWMEVersion()} initialized`);
+        sdk.Events.once({ eventName: "wme-ready" }).then(rsaInit).catch((e: any) => {
+            console.error("RSA: Error in rsaInit promise chain", e);
+        });
+    } catch (e: any) {
+        console.error("RSA: Error in SDK initialization", e);
+    }
+}).catch((e: any) => {
+    console.error("RSA: Error in SDK_INITIALIZED promise", e);
 });
 
 function rsaInit() {
@@ -48,9 +59,8 @@ function rsaInit() {
     const GF_LINK = "https://greasyfork.org/en/scripts/425050-wme-road-shield-assisstant";
     const FORUM_LINK = "https://www.waze.com/discuss/t/script-road-shield-assistant-rsa/227100";
     const RSA_UPDATE_NOTES = `<b>NEW:</b><br>
-    - Make Configurations External and Managed via Google Sheets<br>
+    - Remove Waze Wrap Remote Storage<br>
 <b>BUGFIXES:</b><br>
-    - Issue with Minor Highways or Greater<br>
 <b>KNOWN ISSUES:</b><br><br>`;
 
     enum CountryID {
@@ -424,13 +434,14 @@ function rsaInit() {
     }
     type RoadInfo = Record<string, number | Set<number>>;
     type StateRoadInfo = Record<string, RoadInfo>;
-    type CountryRoadInfo = Record<number, StateRoadInfo>;
+    type CountryRoadInfo = Record<number, StateRoadInfo | false>;
     type CountryDataSheetMap = Record<number, string>;
 
     const CountryDataSheetInfo: CountryDataSheetMap = {};
 
     const RoadAbbr: CountryRoadInfo = {};
     let mainSheetLoaded = false;
+    const loadingCountries = new Set<number>();  // Track which countries are currently being loaded
     const iconsAllowingNoText = new Set<number>([
         2000, // Atlantic City Expy
         2079, // Garden State Parkway
@@ -1041,10 +1052,13 @@ function rsaInit() {
         );
 
         // WazeWrap.Interface.Tab('RSA', $rsaTab.html, setupOptions, 'RSA');
-        sdk.Sidebar.registerScriptTab().then((r) => {
+        sdk.Sidebar.registerScriptTab().then(async (r: any) => {
+            console.log("RSA: Registering sidebar tab");
             r.tabLabel.innerHTML = "RSA";
             r.tabPane.innerHTML = $rsaTab.html;
-            setupOptions();
+            console.log("RSA: Starting setupOptions");
+            await setupOptions();
+            console.log("RSA: setupOptions complete");
         });
         $(`<style type="text/css">${rsaCss}</style>`).appendTo("head");
         // $($rsaFixInner).appendTo($rsaFixWrapper);
@@ -1125,7 +1139,13 @@ function rsaInit() {
     }
 
     async function setupOptions() {
-        await loadSettings();
+        console.log("RSA: setupOptions started");
+        try {
+            await loadSettings();
+            console.log("RSA: loadSettings complete");
+        } catch (e) {
+            console.error("RSA: Error in loadSettings", e);
+        }
 
         // Create OL layer for display
 
@@ -1224,29 +1244,22 @@ function rsaInit() {
         sdk.Events.on({ eventName: "wme-map-move-end", eventHandler: updateMap });
         sdk.Events.on({ eventName: "wme-map-zoom-changed", eventHandler: updateMap });
 
+        const shortcutKeys = "A+83";
+        const keysInUse = sdk.Shortcuts.areShortcutKeysInUse({ shortcutKeys });
+
+        if (keysInUse) {
+            console.warn("RSA: Shortcut key A+S was already in use, registering addShield without a key binding.");
+        }
+
         try {
             sdk.Shortcuts.createShortcut({
                 callback: addShieldClick,
                 description: "Activates the Add Shield Button",
                 shortcutId: "addShield",
-                shortcutKeys: "A+83",
+                shortcutKeys: keysInUse ? null : shortcutKeys,
             });
         } catch (e) {
-            if (e instanceof Error && e.message.includes("already in use")) {
-                console.warn("RSA: Shortcut key A+S was already in use, registering addShield without a key binding.");
-                try {
-                    sdk.Shortcuts.createShortcut({
-                        callback: addShieldClick,
-                        description: "Activates the Add Shield Button",
-                        shortcutId: "addShield",
-                        shortcutKeys: null,
-                    });
-                } catch (retryError) {
-                    console.error("RSA: Failed to register addShield shortcut even with null keys:", retryError);
-                }
-            } else {
-                console.error("RSA: Failed to register addShield shortcut:", e);
-            }
+            console.error("RSA: Failed to register addShield shortcut:", e);
         }
         // new WazeWrap.Interface.Shortcut('addShield',
         //                                 'Activates the Add Shield Button',
@@ -1363,70 +1376,161 @@ function rsaInit() {
         checkOptions();
     }
 
-    const apiKey = "AIzaSyDJaCD-PqytSPVrXZMLqI2UNIsTuy_yLRY";
     const mainRoadSheetID = "10RiokHwpEdcDu5AotXVBbesAzixDSCm9y5x44TRsToI";
-    async function loadCountryAbbr(countryId: number, sheetKey: string) {
-        if(!mainSheetLoaded) return;
-        // Load road abbreviation data
-        $.ajaxSetup({ async: false})
-        await $.getJSON(`https://sheets.googleapis.com/v4/spreadsheets/${sheetKey}?includeGridData=true&key=${apiKey}`)
-        .done(async (spreadSheet) => {
-            const countryWide: StateRoadInfo = {};
-            let setCountry = false;
-            for (const sheet of spreadSheet.sheets) {
-                if (sheet.properties.title === "Reference") continue;
-                if(sheet.data[0].rowData.length <= 1) continue;
-                const stateWide: RoadInfo = {};
-                for (const row of sheet.data[0].rowData) {
-                    if (row.values && row.values.length >= 2) {
-                        const matchingRegex = row.values[0].formattedValue;
-                        if (matchingRegex === "Matching Condition") continue;
-                        const shieldId = Number.parseInt(row.values[1].formattedValue, 10);
-                        stateWide[matchingRegex] = shieldId;
-                    }
-                }
-                countryWide[sheet.properties.title] = stateWide;
-                setCountry = true;
-            }
-            if(setCountry) RoadAbbr[countryId] = countryWide;
-        }).fail(() => {
-            console.error("RSA: Unable to load road abbreviation data from Google Sheets");
-        });
-        $.ajaxSetup({ async: true })
+    const gvizCache = new Map<string, Promise<any>>();  // Cache parsed gviz responses by URL
 
+    async function parseGvizResponse(responseText: string) {
+        const match = responseText.match(/google\.visualization\.Query\.setResponse\(([\s\S]+)\);/);
+        if (!match) {
+            throw new Error("Failed to parse Google Sheet data");
+        }
+        return JSON.parse(match[1]);
     }
 
-    function loadMainRoadAbbr() {
-        $.getJSON(`https://sheets.googleapis.com/v4/spreadsheets/${mainRoadSheetID}?includeGridData=true&key=${apiKey}`, (spreadSheet) => {
-            for(const sheet of spreadSheet.sheets) {
-                if(sheet.properties.title === "CountryData") {
-                    for(const row of sheet.data[0].rowData) {
-                        if(row.values && row.values.length >= 2) {
-                            const country = row.values[0].formattedValue;
-                            if(country === "Country") continue;
-                            const countryCode = Number.parseInt(row.values[1].formattedValue, 10);
-                            if(row.values.length >= 3) {
-                                const sheetKey = row.values[2].formattedValue;
-                                CountryDataSheetInfo[countryCode] = sheetKey;
-                            }
-                        }
-                    }
-                }
-            }
-            mainSheetLoaded = true;
-        }).done(() => {
-            console.log("RSA: Main Road Abbreviations are Loaded");
-        }).fail(() => {
-            console.error("RSA: Unable to load road abbreviation data from Google Sheets");
-        });
-    }
-    async function loadSettings() {
-        const localSettings = JSON.parse(<string>localStorage.getItem("RSA_Settings"));
-        const serverSettings = await WazeWrap.Remote.RetrieveSettings("RSA_Settings");
-        if (!serverSettings) {
-            console.error("RSA: Error communicating with WW settings server");
+    async function gvizFetch(url: string): Promise<any> {
+        // Return cached parsed response if available
+        if (gvizCache.has(url)) {
+            console.log(`RSA: gvizFetch (cached) for URL: ${url}`);
+            return gvizCache.get(url)!;
         }
 
+        console.log(`RSA: gvizFetch called with URL: ${url}`);
+        const promise = new Promise<any>((resolve, reject) => {
+            GM_xmlhttpRequest({
+                method: "GET",
+                url: url,
+                timeout: 10000,
+                onload: (response) => {
+                    console.log(`RSA: gviz request to ${url} returned status ${response.status}`);
+                    if (response.status === 200) {
+                        try {
+                            const json = parseGvizResponse(response.responseText);
+                            resolve(json);
+                        } catch (e) {
+                            reject(e);
+                        }
+                    } else {
+                        const err = new Error(`HTTP ${response.status}: ${response.statusText} from ${url}`);
+                        console.error(`RSA: HTTP error`, err);
+                        reject(err);
+                    }
+                },
+                onerror: (err) => {
+                    console.error("RSA: gviz request error", err);
+                    reject(err);
+                },
+                ontimeout: () => {
+                    console.error("RSA: gviz request timeout");
+                    reject(new Error("Request timeout"));
+                },
+            });
+        });
+
+        // Cache the promise
+        gvizCache.set(url, promise);
+        return promise;
+    }
+
+    async function loadCountryAbbr(countryId: number, sheetKey: string, stateName?: string) {
+        if (!mainSheetLoaded || loadingCountries.has(countryId)) return;
+
+        loadingCountries.add(countryId);
+
+        try {
+            const countryWide: StateRoadInfo = {};
+
+            // Determine which sheets to load
+            let sheetsToLoad: string[] = [""];  // Always load country-wide (default) sheet
+
+            // If a specific state is requested, load only that state + country-wide
+            if (stateName) {
+                sheetsToLoad.push(stateName);
+            } else {
+                // Initial load: just load country-wide sheet for fast startup
+                // State sheets will be loaded on-demand when needed
+                sheetsToLoad = [""];
+            }
+
+            // Load sheets in parallel
+            const sheetPromises = sheetsToLoad.map(async (sheetName) => {
+                try {
+                    const sheetUrl = sheetName
+                        ? `https://docs.google.com/spreadsheets/d/${sheetKey}/gviz/tq?tqx=out:json&sheet=${encodeURIComponent(sheetName)}`
+                        : `https://docs.google.com/spreadsheets/d/${sheetKey}/gviz/tq?tqx=out:json`;
+
+                    const json = await gvizFetch(sheetUrl);
+
+                    if (json.table && json.table.rows && json.table.rows.length > 0) {
+                        const sheetData: Record<string, number> = {};
+
+                        for (const row of json.table.rows) {
+                            if (!row.c || row.c.length < 2) continue;
+
+                            const abbr = row.c[0]?.v;
+                            const iconIdValue = row.c[1]?.v;
+
+                            if (!abbr || typeof abbr !== "string" || iconIdValue === null || iconIdValue === undefined) continue;
+
+                            const iconID = typeof iconIdValue === "number" ? iconIdValue : parseInt(iconIdValue, 10);
+                            sheetData[abbr] = iconID;
+                        }
+                        return { sheetName, sheetData, count: Object.keys(sheetData).length };
+                    }
+                } catch (e) {
+                    // Sheet might not exist, skip it
+                }
+                return null;
+            });
+
+            const results = await Promise.allSettled(sheetPromises);
+            for (const result of results) {
+                if (result.status === "fulfilled" && result.value) {
+                    const { sheetName, sheetData } = result.value;
+                    countryWide[sheetName] = sheetData;
+                }
+            }
+
+            if (Object.keys(countryWide).length > 0 && Object.values(countryWide).some(state => Object.keys(state).length > 0)) {
+                RoadAbbr[countryId] = countryWide;
+            }
+        } catch (e) {
+            console.error("RSA: Unable to load road abbreviation data from Google Sheets", e);
+        } finally {
+            loadingCountries.delete(countryId);
+        }
+    }
+
+    async function loadMainRoadAbbr() {
+        try {
+            const gvizUrl = `https://docs.google.com/spreadsheets/d/${mainRoadSheetID}/gviz/tq?tqx=out:json&sheet=${encodeURIComponent("CountryData")}`;
+            const json = await gvizFetch(gvizUrl);
+
+            if (json.table && json.table.rows) {
+                for (const row of json.table.rows) {
+                    if (!row.c || row.c.length < 3) continue;
+
+                    const country = row.c[0]?.v;
+                    if (!country || country === "Country") continue;
+
+                    const countryCode = parseInt(row.c[1]?.v ?? "0", 10);
+                    const sheetKey = row.c[2]?.v;
+
+                    if (countryCode && sheetKey) {
+                        CountryDataSheetInfo[countryCode] = sheetKey;
+                    }
+                }
+            }
+
+            mainSheetLoaded = true;
+            console.log("RSA: Main Road Abbreviations are Loaded");
+        } catch (e) {
+            console.error("RSA: Unable to load road abbreviation data from Google Sheets", e);
+        }
+    }
+    async function loadSettings() {
+        console.log("RSA: loadSettings started");
+        const localSettings = JSON.parse(<string>localStorage.getItem("RSA_Settings"));
+        console.log("RSA: localSettings parsed, calling loadMainRoadAbbr");
         const defaultSettings: RSASettings = {
             lastSaveAction: 0,
             enableScript: true,
@@ -1465,14 +1569,7 @@ function rsaInit() {
         };
 
         rsaSettings = $.extend({}, defaultSettings, localSettings);
-        if (serverSettings && serverSettings.lastSaveAction > rsaSettings.lastSaveAction) {
-            $.extend(rsaSettings, serverSettings);
-            // console.log('RSA: server settings used');
-        } else {
-            // console.log('RSA: local settings used');
-        }
-
-        loadMainRoadAbbr();
+        await loadMainRoadAbbr();
     }
 
     async function saveSettings() {
@@ -1582,15 +1679,6 @@ function rsaInit() {
 
         if (localStorage) {
             localStorage.setItem("RSA_Settings", JSON.stringify(localSettings));
-        }
-        const serverSave = await WazeWrap.Remote.SaveSettings("RSA_Settings", localSettings);
-
-        if (serverSave === null) {
-            console.warn("RSA: User PIN not set in WazeWrap tab");
-        } else {
-            if (serverSave === false) {
-                console.error("RSA: Unable to save settings to server");
-            }
         }
     }
 
@@ -1735,7 +1823,7 @@ function rsaInit() {
         }
     }
 
-    function tryScan() {
+    async function tryScan() {
         if (!rsaSettings.enableScript) return;
 
         // Reset the array of objects that need names fixed
@@ -1756,7 +1844,7 @@ function rsaInit() {
             //     scanSeg(s);
             // }
             for (const s of sdk.DataModel.Segments.getAll()) {
-                processSeg(s);
+                await processSeg(s);
             }
         }
         // Scan all nodes on screen
@@ -1769,7 +1857,7 @@ function rsaInit() {
     }
 
     const majorRoads = new Set<number>([3, 4, 6, 7]);
-    function processSeg(seg: Segment) {
+    async function processSeg(seg: Segment) {
         if (
             (!rsaSettings.ShowRamps && seg.roadType === 4) ||
             (rsaSettings.mHPlus && !majorRoads.has(seg.roadType))
@@ -1808,7 +1896,7 @@ function rsaInit() {
         // let oldStateName = W.model.states.getObjectById(cityID.stateID).attributes.name;
         const stateName: string = address.state === null ? "" : address.state.name;
         const countryID = address.country?.id;
-        const candidate: Candidate = isSegmentCandidate(address, stateName, countryID);
+        const candidate: Candidate = await isSegmentCandidate(address, stateName, countryID);
 
         // Display shield on map
         function checkDeclutterSettings(seg: Segment): boolean {
@@ -1895,11 +1983,11 @@ function rsaInit() {
     }
 
     // Function written by kpouer to accommodate French conventions of shields being based on alt names
-    function isSegmentCandidate(address: SegmentAddress, stateName: string, countryId: number | null | undefined) {
-        let candidate = isStreetCandidate(address.street, stateName, countryId);
+    async function isSegmentCandidate(address: SegmentAddress, stateName: string, countryId: number | null | undefined): Promise<Candidate> {
+        let candidate = await isStreetCandidate(address.street, stateName, countryId);
         if (!candidate.isCandidate && address.country !== null && address.country?.id !== undefined && CheckAltName.has(address.country.id)) {
             for (const altAddress of address.altStreets) {
-                candidate = isStreetCandidate(altAddress.street, stateName, countryId);
+                candidate = await isStreetCandidate(altAddress.street, stateName, countryId);
                 if (candidate.isCandidate) {
                     return candidate;
                 }
@@ -1908,7 +1996,7 @@ function rsaInit() {
         return candidate;
     }
 
-    function isStreetCandidate(street: Street | null, stateName: string, countryId: number | null | undefined): Candidate {
+    async function isStreetCandidate(street: Street | null, stateName: string, countryId: number | null | undefined): Promise<Candidate> {
         const info: Candidate = { isCandidate: false, iconID: null };
 
         if (street === null || countryId === null || countryId === undefined) {
@@ -1923,12 +2011,12 @@ function rsaInit() {
                 RoadAbbr[countryId] = false;
                 return info;
             }
-            loadCountryAbbr(countryId, CountryDataSheetInfo[countryId]);
+            await loadCountryAbbr(countryId, CountryDataSheetInfo[countryId], stateName);
         }
         // if (stateName === null) stateName = "";
 
         //Check to see if the country has states configured in RSA by looking for a key with nothing in it
-        if (street.name) {
+        if (street.name && typeof RoadAbbr[countryId] === "object") {
             const noStates: boolean = ("" in RoadAbbr[countryId]);
             const abbrvs = noStates
                 ? RoadAbbr[countryId][""]

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,34 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
+	"vcs": {
+		"enabled": true,
+		"clientKind": "git",
+		"useIgnoreFile": true
+	},
+	"files": {
+		"ignoreUnknown": false
+	},
+	"formatter": {
+		"enabled": true,
+		"indentStyle": "tab"
+	},
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true
+		}
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "double"
+		}
+	},
+	"assist": {
+		"enabled": true,
+		"actions": {
+			"source": {
+				"organizeImports": "on"
+			}
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "wme-road-shield-assistant",
   "devDependencies": {
-    "@biomejs/biome": "^2.3.10",
+    "@biomejs/biome": "2.4.12",
     "@turf/turf": "^7.3.1",
-    "@types/jquery": "^3.5.33",
+    "@types/jquery": "^4.0.0",
     "@types/tampermonkey": "^5.0.5",
     "@types/underscore": "^1.13.0",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "underscore": "^1.13.7",
     "wme-sdk-typings": "https://web-assets.waze.com/wme_sdk_docs/beta/latest/wme-sdk-typings.tgz"
   },
@@ -24,6 +24,6 @@
   "private": true,
   "dependencies": {
     "jquery": "^3.7.1",
-    "prettier": "^3.6.2"
+    "prettier": "^3.8.3"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "target": "es2022",
     "module": "ES2022",
-    "moduleResolution": "node10",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,


### PR DESCRIPTION
Problem

When the addShield shortcut was registered with shortcutKeys: "A+83" or "ALT+S", if that key combination was already claimed by another script or WME feature, sdk.Shortcuts.createShortcut would throw an InvalidStateError. This exception was unhandled, causing setupOptions to abort silently — leaving layers, event listeners, and UI elements uninitialized.

Fix

Wrapped the createShortcut call in a try/catch with a two-stage fallback:

1. First attempt — registers the shortcut with the default A+S key binding as before.
2. On "already in use" error — retries with shortcutKeys: null, registering the shortcut without a key binding. The user can assign a conflict-free key manually via WME's keyboard shortcuts panel. 
3. Any other error — logged to console with the RSA: prefix and does not interrupt script initialization.